### PR TITLE
delete previously uploaded artifacts

### DIFF
--- a/.github/workflows/build-yocto-images-artifactory.yml
+++ b/.github/workflows/build-yocto-images-artifactory.yml
@@ -59,6 +59,10 @@ jobs:
             python3 -m pip install \
               git+https://${{secrets.PAT_GITHUB}}@github.com/ZoetisDenmark/vetscan-pipeline-tools#subdirectory=artifact-tools
 
+            echo "Deleting previous artifacts"
+            delete-artifacts --user admin --password ${{secrets.ARTIFACTORY_PASSWORD}} \
+                            --repository "${{env.ARTIFACT_REPO}}" --version "${{env.VERSION}}" 
+
             TMP_ARTIFACTS_DIR=$(mktemp -d)
             echo "Created temporary directory: $TMP_ARTIFACTS_DIR"
 


### PR DESCRIPTION
We're doing this because to avoid uploading multiple artifacts to the same folder and causing problems elsewhere in our CI/CD setup. So to avoid that situation we're deleting previous artifacts for the same branch/PR before uploading the new ones. 